### PR TITLE
Responsive chart

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ function App() {
             <Grid item sm={12} md={8}>
               <Intro />
             </Grid>
-            <Grid item sm={12} md={12}>
+            <Grid item sm={12} md={12} style={{width: '100%'}}>
               <Chart />
             </Grid>
             <Grid item sm={12} md={12}>

--- a/src/components/Chart/Chart.css
+++ b/src/components/Chart/Chart.css
@@ -1,6 +1,5 @@
 .chart {
-  /*margin: 1em;
-  margin-top: 0;*/
+  width: 100%;
   margin: 1em 1em 1em 0;
   color: #000;
   max-width: 100%;
@@ -8,10 +7,12 @@
 
 .chart .chartBars {
   display: flex;
+  width: 100%;
 }
 
 .chartBars__wrapper {
   display: flex;
+  width: 100%;
 }
 
 .chart .chartBar-label {
@@ -30,11 +31,7 @@
   }
 
   .chart__container {
-    margin-bottom: 1em;
+    margin: 2em 0;
     padding: 0;
-  }
-
-  .chartBars__wrapper {
-    justify-content: space-between;
   }
 }

--- a/src/components/Chart/Chart.css
+++ b/src/components/Chart/Chart.css
@@ -17,7 +17,24 @@
 .chart .chartBar-label {
   transform: rotate(180deg);
 }
+
 .chart__container {
 	display: flex;
 	padding: 2em 2em 2em 0;
+}
+
+@media(max-width: 768px){
+  .chart, .chartBars {
+    margin: 0;
+    width: 100%;
+  }
+
+  .chart__container {
+    margin-bottom: 1em;
+    padding: 0;
+  }
+
+  .chartBars__wrapper {
+    justify-content: space-between;
+  }
 }

--- a/src/components/ChartBar/ChartBar.css
+++ b/src/components/ChartBar/ChartBar.css
@@ -27,7 +27,7 @@
   /* override inline style from rnd library */
   top: unset !important;margin-left: 0px;
   left: 0px;
-  border-top: 10px solid rgb(0, 0, 0, 0.2);
+  border-top: 6px solid rgb(0, 0, 0, 0.2);
 }
 
 .chartBar .chartBar-label {

--- a/src/components/ChartBar/ChartBar.css
+++ b/src/components/ChartBar/ChartBar.css
@@ -27,6 +27,7 @@
   /* override inline style from rnd library */
   top: unset !important;margin-left: 0px;
   left: 0px;
+  border-top: 10px solid rgb(0, 0, 0, 0.2);
 }
 
 .chartBar .chartBar-label {

--- a/src/components/ChartBar/ChartBar.css
+++ b/src/components/ChartBar/ChartBar.css
@@ -37,19 +37,27 @@
   left: 4px;
 }
 
+@media(max-width: 1176px){
+  .chartBar .chartBar-color {
+    /* override inline style from rnd library */
+    width: 50px !important;
+  }
+}
+
 @media(max-width: 768px){
   .chartBars__wrapper {
     width: 100%;
     max-width: 85vw;
-    justify-content: space-evenly;
+    justify-content: space-around;
   }
 
   .chartBar {
     width: auto;
+    margin: 0;
   }
 }
 
-@media(max-width: 411px){
+@media(max-width: 705px){
   .chartBar .chartBar-color {
     /* override inline style from rnd library */
     width: 24px !important;

--- a/src/components/ChartBar/ChartBar.css
+++ b/src/components/ChartBar/ChartBar.css
@@ -36,3 +36,26 @@
   bottom: 20px;
   left: 4px;
 }
+
+@media(max-width: 768px){
+  .chartBars__wrapper {
+    width: 100%;
+    max-width: 85vw;
+    justify-content: space-evenly;
+  }
+
+  .chartBar {
+    width: auto;
+  }
+}
+
+@media(max-width: 411px){
+  .chartBar .chartBar-color {
+    /* override inline style from rnd library */
+    width: 24px !important;
+  }
+
+  .chart .chartBar-label {
+    display: none;
+  }
+}

--- a/src/components/ChartBar/ChartBar.js
+++ b/src/components/ChartBar/ChartBar.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import './ChartBar.css';
 import { Rnd } from 'react-rnd';
+import { withStyles } from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
 import { max, barColors } from '../../config.js';
 
 function ChartBar(props) {
@@ -45,22 +47,41 @@ function ChartBar(props) {
     }
   }
 
+  const ChartTooltip = withStyles({
+    tooltip: {
+      backgroundColor: '#f5f5f9',
+      color: 'rgba(0, 0, 0, 0.87)',
+      maxWidth: 220,
+      border: '1px solid #dadde9',
+    }
+  })(Tooltip);
+
   return (
     <div className='chartBar' id={`chartBar-${data.id}`}>
       <div className='chartBar-label'>{data.label} <br /> ${simpleNum()}</div>
-      <Rnd className='chartBar-color'
-        style={{
-          backgroundColor: barColors[order]
-        }} 
-        default={{
-          width: 30,
-          height: 100,
-        }}
-        size={{ width: 30,  height: getHeight() }}
-        onResizeStop={interactions ? (e, direction, ref, delta) => {
-          updateHeight(delta);
-        } : null}
-      />
+      <ChartTooltip 
+        placement='top' 
+        arrow={true} 
+        title={
+          <React.Fragment>
+            {data.label} <br />
+            ${simpleNum()}
+          </React.Fragment>
+          }>
+        <Rnd className='chartBar-color'
+          style={{
+            backgroundColor: barColors[order]
+          }} 
+          default={{
+            width: 30,
+            height: 100,
+          }}
+          size={{ width: 30,  height: getHeight() }}
+          onResizeStop={interactions ? (e, direction, ref, delta) => {
+            updateHeight(delta);
+          } : null}
+        />
+      </ChartTooltip>
     </div>
   );
 }

--- a/src/components/ChartBar/ChartBar.js
+++ b/src/components/ChartBar/ChartBar.js
@@ -49,10 +49,23 @@ function ChartBar(props) {
 
   const ChartTooltip = withStyles({
     tooltip: {
-      backgroundColor: '#f5f5f9',
-      color: 'rgba(0, 0, 0, 0.87)',
+      backgroundColor: barColors[order],
+      color: barColors[order] === 'black' ? '#ffffff' : '#000000',
       maxWidth: 220,
-      border: '1px solid #dadde9',
+      padding: '15px',
+      fontSize: '0.75rem',
+      fontWeight: 700,
+      border: '1px solid #000000',
+      "@media (min-width:768px)": {
+        display: 'none',
+      },
+    },
+    arrow: {
+      "&::before": {
+        border: '1px solid #000000',
+        backgroundColor: barColors[order],
+        boxSizing: "border-box"
+      }
     }
   })(Tooltip);
 
@@ -60,8 +73,8 @@ function ChartBar(props) {
     <div className='chartBar' id={`chartBar-${data.id}`}>
       <div className='chartBar-label'>{data.label} <br /> ${simpleNum()}</div>
       <ChartTooltip 
-        placement='top' 
-        arrow={true} 
+        arrow
+        placement='top'  
         title={
           <React.Fragment>
             {data.label} <br />

--- a/src/components/ChartScale/ChartScale.css
+++ b/src/components/ChartScale/ChartScale.css
@@ -16,14 +16,17 @@
     border-top: 1px solid #000;
 }
 
-.chart-scale__label::before {
+.chart-scale__label__number {
     display: none;
 }
 
-.chart-scale__label::after {
-    display: inline-flex;
-    margin-left: 5px;
-    width: 10px;
-    height: 14px;
-    content: "";
+@media(max-width: 768px){
+    .chart-scale__label__text {
+        display: none;
+    }
+    .chart-scale__label__number {
+        display: block;
+        margin-right: 4px;
+    }
 }
+

--- a/src/components/ChartScale/ChartScale.js
+++ b/src/components/ChartScale/ChartScale.js
@@ -8,7 +8,11 @@ const ChartScale = (props) => {
     return (
         <div className="chart-scale">
             <div className="chart-scale__label-container">
-                {labels.map((text, index) => <div style={{height: `${height / labels.length}%`}} className="chart-scale__label" key={index}>{text}</div>)}
+                {labels.map((text, index) => 
+                    <div style={{height: `${height / labels.length}%`}} className="chart-scale__label" key={index}>
+                        <div className="chart-scale__label__text">{text}</div>
+                        <div className="chart-scale__label__number">{index + 1}</div>
+                    </div>)}
             </div>
         </div>
     )

--- a/src/theme.js
+++ b/src/theme.js
@@ -8,6 +8,9 @@ const theme = createMuiTheme({
             fontWeight: '700',
             fontStyle: 'italic',
             fontSize: '2.5rem',
+            '@media (max-width:414px)': {
+                fontSize: '2rem',
+              },
         },
         h2: {
             fontFamily: 'Roboto Mono',


### PR DESCRIPTION
![Screen Shot 2020-06-22 at 5 31 00 PM](https://user-images.githubusercontent.com/40442988/85337278-2964c300-b4ae-11ea-8b0a-87a8765a55e6.png)

- Added breakpoints for chart size
- Added tooltips for small screens
- To help with the UI I added a darker top border to the bars to make it a little more clear that the bars can be adjusted by dragging the top. Maybe there is a better way of doing this.